### PR TITLE
chore: export hook types

### DIFF
--- a/typescript/src/hooks/index.ts
+++ b/typescript/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -3,3 +3,4 @@ export * from './vault/vault';
 export * from './vault/types';
 export * from './weighted';
 export * from './buffer';
+export * from './hooks';


### PR DESCRIPTION
As part of the https://github.com/balancer/backend/pull/896 I will be using `HookState`.