### PR TITLE
Add gyro ECLP validations

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -9,7 +9,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "version": "0.0.23",
+    "version": "0.0.24",
     "main": "dist/index.js",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",

--- a/typescript/src/gyro/gyroECLPMath.ts
+++ b/typescript/src/gyro/gyroECLPMath.ts
@@ -1,4 +1,4 @@
-
+import { GyroPoolMath } from './gyroPoolMath';
 import { SignedFixedPoint } from './signedFixedPoint';
 import {_require} from '../utils/math';
 

--- a/typescript/src/gyro/gyroECLPMath.ts
+++ b/typescript/src/gyro/gyroECLPMath.ts
@@ -1,5 +1,6 @@
-import { GyroPoolMath } from './gyroPoolMath';
+
 import { SignedFixedPoint } from './signedFixedPoint';
+import {_require} from '../utils/math';
 
 export interface Vector2 {
     x: bigint;
@@ -75,6 +76,37 @@ export class GyroECLPMath {
     static readonly MIN_INVARIANT_RATIO = BigInt('600000000000000000'); // 60e16 (60%)
     // Invariant shrink limit: non-proportional remove cannot cause the invariant to decrease by less than this ratio
     static readonly MAX_INVARIANT_RATIO = BigInt('5000000000000000000'); // 500e16 (500%)
+
+    static validateParams(params: EclpParams): void {
+        _require(0 <= params.s && params.s <= this._ONE, `s must be >= 0 and <= ${this._ONE}`);
+        _require(0 <= params.c && params.c <= this._ONE, `c must be >= 0 and <= ${this._ONE}`);
+
+        const sc:Vector2 = {x: params.s, y: params.c};
+        const scnorm2 = this.scalarProd(sc, sc);
+
+        _require(this._ONE - this._ROTATION_VECTOR_NORM_ACCURACY <= scnorm2 && scnorm2 <= this._ONE + this._ROTATION_VECTOR_NORM_ACCURACY, 'RotationVectorNotNormalized()');
+        _require(0 <= params.lambda && params.lambda <= this._MAX_STRETCH_FACTOR,`lambda must be >= 0 and <= ${this._MAX_STRETCH_FACTOR}`);
+    }
+
+
+    static validateDerivedParams(params: EclpParams, derived: DerivedEclpParams): void {
+        _require(derived.tauAlpha.y > 0, 'tuaAlpha.y must be > 0');
+        _require(derived.tauBeta.y > 0, 'tauBeta.y must be > 0');
+        _require(derived.tauBeta.x > derived.tauAlpha.x, 'tauBeta.x must be > tauAlpha.x');
+
+        const norm2 = this.scalarProdXp(derived.tauAlpha, derived.tauAlpha);
+
+        _require(this._ONE_XP - this._DERIVED_TAU_NORM_ACCURACY_XP <= norm2 && norm2 <= this._ONE_XP + this._DERIVED_TAU_NORM_ACCURACY_XP, 'RotationVectorNotNormalized()')
+        _require(derived.u <= this._ONE_XP, `u must be <= ${this._ONE_XP}`);
+        _require(derived.v <= this._ONE_XP, `v must be <= ${this._ONE_XP}`);
+        _require(derived.w <= this._ONE_XP, `w must be <= ${this._ONE_XP}`);
+        _require(derived.z <= this._ONE_XP, `z must be <= ${this._ONE_XP}`);
+
+        _require(this._ONE_XP - this._DERIVED_DSQ_NORM_ACCURACY_XP <= derived.dSq && derived.dSq <= this._ONE_XP + this._DERIVED_DSQ_NORM_ACCURACY_XP, "DerivedDsqWrong()");
+
+        const mulDenominator = SignedFixedPoint.divXpU(this._ONE_XP, (this.calcAChiAChiInXp(params, derived) - this._ONE_XP));
+        _require(mulDenominator <= this._MAX_INV_INVARIANT_DENOMINATOR_XP, `mulDenominator must be <= ${this._MAX_INV_INVARIANT_DENOMINATOR_XP}`);
+    }
 
     static scalarProd(t1: Vector2, t2: Vector2): bigint {
         const xProd = SignedFixedPoint.mulDownMag(t1.x, t2.x);

--- a/typescript/src/utils/math.ts
+++ b/typescript/src/utils/math.ts
@@ -13,7 +13,7 @@ export const min = (values: bigint[]): bigint =>
 export const max = (values: bigint[]): bigint =>
     values.reduce((a, b) => (a > b ? a : b));
 
-const _require = (b: boolean, message: string) => {
+export const _require = (b: boolean, message: string) => {
     if (!b) throw new Error(message);
 };
 


### PR DESCRIPTION
Plan is to use this for  https://github.com/balancer/b-sdk/pull/570

### Summary
- Tried to match syntax of SC implementation as close as possible 
- Tried to be helpful with error messages
  - For simple checks directly on param values, offer range values in error message
  - For validations that do math on params then check range, just use custom error name


