### PR TITLE
Add QuantAmm implementation for typescript

### DIFF
--- a/testData/config.json
+++ b/testData/config.json
@@ -410,6 +410,93 @@
                     "tokenOut": "0xb19382073c7A0aDdbb56Ac6AF1808Fa49e377B75"
                 }
             ]
+        },
+        {
+            "testName": "QuantAMM",
+            "chainId": "11155111",
+            "blockNumber": "8275355",
+            "poolAddress": "0xa3a6398f3b29b84a6657a1f4bce5c90f38462bf7",
+            "poolType": "QUANT_AMM_WEIGHTED",
+            "swaps": [
+                {
+                    "swapKind": 0,
+                    "amountRaw": "10000000",
+                    "tokenIn": "0x29f2d40b0605204364af54ec677bd022da425d03",
+                    "tokenOut": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8"
+                },
+                {
+                    "swapKind": 1,
+                    "amountRaw": "100000",
+                    "tokenIn": "0x29f2d40b0605204364af54ec677bd022da425d03",
+                    "tokenOut": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8"
+                },
+                {
+                    "swapKind": 0,
+                    "amountRaw": "1000000",
+                    "tokenIn": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+                    "tokenOut": "0x29f2d40b0605204364af54ec677bd022da425d03"
+                },
+                {
+                    "swapKind": 1,
+                    "amountRaw": "2000000",
+                    "tokenIn": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+                    "tokenOut": "0x29f2d40b0605204364af54ec677bd022da425d03"
+                }
+            ],
+            "adds": [
+                {
+                    "kind": "Unbalanced",
+                    "inputAmountsRaw": ["10000000", "10000000"],
+                    "tokens": [
+                        "0x29f2d40b0605204364af54ec677bd022da425d03",
+                        "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8"
+                    ],
+                    "decimals": [8, 6]
+                },
+                {
+                    "kind": "SingleToken",
+                    "bptOutRaw": ["10000000"],
+                    "tokenIn": "0x29f2d40b0605204364af54ec677bd022da425d03",
+                    "decimals": 8
+                },
+                {
+                    "kind": "SingleToken",
+                    "bptOutRaw": ["10000000"],
+                    "tokenIn": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+                    "decimals": 6
+                }
+            ],
+            "removes": [
+                {
+                    "kind": "Proportional",
+                    "bpt": "0xa3a6398f3b29b84a6657a1f4bce5c90f38462bf7",
+                    "bptInRaw": "100000000000000000"
+                },
+                {
+                    "kind": "SingleTokenExactIn",
+                    "bpt": "0xa3a6398f3b29b84a6657a1f4bce5c90f38462bf7",
+                    "bptInRaw": "100000000000000000",
+                    "token": "0x29f2d40b0605204364af54ec677bd022da425d03"
+                },
+                {
+                    "kind": "SingleTokenExactIn",
+                    "bpt": "0xa3a6398f3b29b84a6657a1f4bce5c90f38462bf7",
+                    "bptInRaw": "100000000000000000",
+                    "token": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8"
+                },
+                {
+                    "kind": "SingleTokenExactOut",
+                    "token": "0x29f2d40b0605204364af54ec677bd022da425d03",
+                    "amountOutRaw": "10000000",
+                    "decimals": 8
+                },
+                {
+                    "kind": "SingleTokenExactOut",
+                    "token": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+                    "amountOutRaw": "10000000",
+                    "decimals": 6
+                }
+            ]
         }
     ]
 }

--- a/testData/src/abi/liquidityBootstrapping.ts
+++ b/testData/src/abi/liquidityBootstrapping.ts
@@ -1375,4 +1375,4 @@ export const liquidityBootstrappingAbi = [
         stateMutability: 'view',
         type: 'function',
     },
-];
+] as const;

--- a/testData/src/abi/quantAmm.ts
+++ b/testData/src/abi/quantAmm.ts
@@ -1,0 +1,1112 @@
+export const quantAmmAbi = [
+    {
+        inputs: [
+            {
+                components: [
+                    { internalType: 'string', name: 'name', type: 'string' },
+                    { internalType: 'string', name: 'symbol', type: 'string' },
+                    {
+                        internalType: 'uint256',
+                        name: 'numTokens',
+                        type: 'uint256',
+                    },
+                    { internalType: 'string', name: 'version', type: 'string' },
+                    {
+                        internalType: 'address',
+                        name: 'updateWeightRunner',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'poolRegistry',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'string[][]',
+                        name: 'poolDetails',
+                        type: 'string[][]',
+                    },
+                ],
+                internalType: 'struct QuantAMMWeightedPool.NewPoolParams',
+                name: 'params',
+                type: 'tuple',
+            },
+            { internalType: 'contract IVault', name: 'vault', type: 'address' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+    },
+    { inputs: [], name: 'BaseOutOfBounds', type: 'error' },
+    { inputs: [], name: 'ECDSAInvalidSignature', type: 'error' },
+    {
+        inputs: [{ internalType: 'uint256', name: 'length', type: 'uint256' }],
+        name: 'ECDSAInvalidSignatureLength',
+        type: 'error',
+    },
+    {
+        inputs: [{ internalType: 'bytes32', name: 's', type: 'bytes32' }],
+        name: 'ECDSAInvalidSignatureS',
+        type: 'error',
+    },
+    {
+        inputs: [
+            { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+        ],
+        name: 'ERC2612ExpiredSignature',
+        type: 'error',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'signer', type: 'address' },
+            { internalType: 'address', name: 'owner', type: 'address' },
+        ],
+        name: 'ERC2612InvalidSigner',
+        type: 'error',
+    },
+    { inputs: [], name: 'ExponentOutOfBounds', type: 'error' },
+    {
+        inputs: [
+            { internalType: 'address', name: 'account', type: 'address' },
+            { internalType: 'uint256', name: 'currentNonce', type: 'uint256' },
+        ],
+        name: 'InvalidAccountNonce',
+        type: 'error',
+    },
+    { inputs: [], name: 'InvalidExponent', type: 'error' },
+    { inputs: [], name: 'InvalidInitialization', type: 'error' },
+    { inputs: [], name: 'InvalidShortString', type: 'error' },
+    { inputs: [], name: 'MaxInRatio', type: 'error' },
+    { inputs: [], name: 'MaxOutRatio', type: 'error' },
+    { inputs: [], name: 'NotInitializing', type: 'error' },
+    { inputs: [], name: 'ProductOutOfBounds', type: 'error' },
+    {
+        inputs: [{ internalType: 'address', name: 'sender', type: 'address' }],
+        name: 'SenderIsNotVault',
+        type: 'error',
+    },
+    {
+        inputs: [{ internalType: 'string', name: 'str', type: 'string' }],
+        name: 'StringTooLong',
+        type: 'error',
+    },
+    { inputs: [], name: 'WeightedPoolBptRateUnsupported', type: 'error' },
+    { inputs: [], name: 'ZeroDivision', type: 'error' },
+    { inputs: [], name: 'ZeroInvariant', type: 'error' },
+    { inputs: [], name: 'maxTradeSizeRatioExceeded', type: 'error' },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'owner',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'spender',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+            },
+        ],
+        name: 'Approval',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [],
+        name: 'EIP712DomainChanged',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'uint64',
+                name: 'version',
+                type: 'uint64',
+            },
+        ],
+        name: 'Initialized',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'rule',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'address[][]',
+                name: 'poolOracles',
+                type: 'address[][]',
+            },
+            {
+                indexed: false,
+                internalType: 'uint64[]',
+                name: 'lambda',
+                type: 'uint64[]',
+            },
+            {
+                indexed: false,
+                internalType: 'int256[][]',
+                name: 'ruleParameters',
+                type: 'int256[][]',
+            },
+            {
+                indexed: false,
+                internalType: 'uint64',
+                name: 'epsilonMax',
+                type: 'uint64',
+            },
+            {
+                indexed: false,
+                internalType: 'uint64',
+                name: 'absoluteWeightGuardRail',
+                type: 'uint64',
+            },
+            {
+                indexed: false,
+                internalType: 'uint40',
+                name: 'updateInterval',
+                type: 'uint40',
+            },
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'poolManager',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'address',
+                name: 'creatorAddress',
+                type: 'address',
+            },
+        ],
+        name: 'PoolRuleSet',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'from',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'to',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'value',
+                type: 'uint256',
+            },
+        ],
+        name: 'Transfer',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'oldAddress',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'newAddress',
+                type: 'address',
+            },
+        ],
+        name: 'UpdateWeightRunnerAddressUpdated',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: 'address',
+                name: 'poolAddress',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                internalType: 'int256[]',
+                name: 'weights',
+                type: 'int256[]',
+            },
+            {
+                indexed: false,
+                internalType: 'uint40',
+                name: 'lastInterpolationTimePossible',
+                type: 'uint40',
+            },
+            {
+                indexed: false,
+                internalType: 'uint40',
+                name: 'lastUpdateTime',
+                type: 'uint40',
+            },
+        ],
+        name: 'WeightsUpdated',
+        type: 'event',
+    },
+    {
+        inputs: [],
+        name: 'DOMAIN_SEPARATOR',
+        outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'PERMIT_TYPEHASH',
+        outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'absoluteWeightGuardRail',
+        outputs: [{ internalType: 'uint64', name: '', type: 'uint64' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'owner', type: 'address' },
+            { internalType: 'address', name: 'spender', type: 'address' },
+        ],
+        name: 'allowance',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'spender', type: 'address' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'approve',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+        name: 'balanceOf',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256[]',
+                name: 'balancesLiveScaled18',
+                type: 'uint256[]',
+            },
+            { internalType: 'uint256', name: 'tokenInIndex', type: 'uint256' },
+            {
+                internalType: 'uint256',
+                name: 'invariantRatio',
+                type: 'uint256',
+            },
+        ],
+        name: 'computeBalance',
+        outputs: [
+            { internalType: 'uint256', name: 'newBalance', type: 'uint256' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256[]',
+                name: 'balancesLiveScaled18',
+                type: 'uint256[]',
+            },
+            { internalType: 'enum Rounding', name: 'rounding', type: 'uint8' },
+        ],
+        name: 'computeInvariant',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'decimals',
+        outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
+        stateMutability: 'pure',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'deploymentTime',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'eip712Domain',
+        outputs: [
+            { internalType: 'bytes1', name: 'fields', type: 'bytes1' },
+            { internalType: 'string', name: 'name', type: 'string' },
+            { internalType: 'string', name: 'version', type: 'string' },
+            { internalType: 'uint256', name: 'chainId', type: 'uint256' },
+            {
+                internalType: 'address',
+                name: 'verifyingContract',
+                type: 'address',
+            },
+            { internalType: 'bytes32', name: 'salt', type: 'bytes32' },
+            {
+                internalType: 'uint256[]',
+                name: 'extensions',
+                type: 'uint256[]',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'owner', type: 'address' },
+            { internalType: 'address', name: 'spender', type: 'address' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'emitApproval',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'from', type: 'address' },
+            { internalType: 'address', name: 'to', type: 'address' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'emitTransfer',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'epsilonMax',
+        outputs: [{ internalType: 'uint64', name: '', type: 'uint64' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getAggregateFeePercentages',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: 'aggregateSwapFeePercentage',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256',
+                name: 'aggregateYieldFeePercentage',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getCurrentLiveBalances',
+        outputs: [
+            {
+                internalType: 'uint256[]',
+                name: 'balancesLiveScaled18',
+                type: 'uint256[]',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMaximumInvariantRatio',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'pure',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMaximumSwapFeePercentage',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'pure',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMinimumInvariantRatio',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'pure',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMinimumSwapFeePercentage',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'pure',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getNormalizedWeights',
+        outputs: [{ internalType: 'uint256[]', name: '', type: 'uint256[]' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getOracleStalenessThreshold',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'string', name: 'category', type: 'string' },
+            { internalType: 'string', name: 'name', type: 'string' },
+        ],
+        name: 'getPoolDetail',
+        outputs: [
+            { internalType: 'string', name: '', type: 'string' },
+            { internalType: 'string', name: '', type: 'string' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getQuantAMMWeightedPoolDynamicData',
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'uint256[]',
+                        name: 'balancesLiveScaled18',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'tokenRates',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'totalSupply',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'isPoolInitialized',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'isPoolPaused',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'isPoolInRecoveryMode',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'int256[]',
+                        name: 'firstFourWeightsAndMultipliers',
+                        type: 'int256[]',
+                    },
+                    {
+                        internalType: 'int256[]',
+                        name: 'secondFourWeightsAndMultipliers',
+                        type: 'int256[]',
+                    },
+                    {
+                        internalType: 'uint40',
+                        name: 'lastUpdateTime',
+                        type: 'uint40',
+                    },
+                    {
+                        internalType: 'uint40',
+                        name: 'lastInteropTime',
+                        type: 'uint40',
+                    },
+                ],
+                internalType:
+                    'struct IQuantAMMWeightedPool.QuantAMMWeightedPoolDynamicData',
+                name: 'data',
+                type: 'tuple',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getQuantAMMWeightedPoolImmutableData',
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'contract IERC20[]',
+                        name: 'tokens',
+                        type: 'address[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'oracleStalenessThreshold',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'poolRegistry',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'int256[][]',
+                        name: 'ruleParameters',
+                        type: 'int256[][]',
+                    },
+                    {
+                        internalType: 'uint64[]',
+                        name: 'lambda',
+                        type: 'uint64[]',
+                    },
+                    {
+                        internalType: 'uint64',
+                        name: 'epsilonMax',
+                        type: 'uint64',
+                    },
+                    {
+                        internalType: 'uint64',
+                        name: 'absoluteWeightGuardRail',
+                        type: 'uint64',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'maxTradeSizeRatio',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint64',
+                        name: 'updateInterval',
+                        type: 'uint64',
+                    },
+                ],
+                internalType:
+                    'struct IQuantAMMWeightedPool.QuantAMMWeightedPoolImmutableData',
+                name: 'data',
+                type: 'tuple',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getRate',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'pure',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getStaticSwapFeePercentage',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getTokenInfo',
+        outputs: [
+            {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+            },
+            {
+                components: [
+                    {
+                        internalType: 'enum TokenType',
+                        name: 'tokenType',
+                        type: 'uint8',
+                    },
+                    {
+                        internalType: 'contract IRateProvider',
+                        name: 'rateProvider',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'paysYieldFees',
+                        type: 'bool',
+                    },
+                ],
+                internalType: 'struct TokenInfo[]',
+                name: 'tokenInfo',
+                type: 'tuple[]',
+            },
+            {
+                internalType: 'uint256[]',
+                name: 'balancesRaw',
+                type: 'uint256[]',
+            },
+            {
+                internalType: 'uint256[]',
+                name: 'lastBalancesLiveScaled18',
+                type: 'uint256[]',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getTokens',
+        outputs: [
+            {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getVault',
+        outputs: [
+            { internalType: 'contract IVault', name: '', type: 'address' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getWithinFixWindow',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'incrementNonce',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    { internalType: 'string', name: 'name', type: 'string' },
+                    { internalType: 'string', name: 'symbol', type: 'string' },
+                    {
+                        components: [
+                            {
+                                internalType: 'contract IERC20',
+                                name: 'token',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'enum TokenType',
+                                name: 'tokenType',
+                                type: 'uint8',
+                            },
+                            {
+                                internalType: 'contract IRateProvider',
+                                name: 'rateProvider',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'bool',
+                                name: 'paysYieldFees',
+                                type: 'bool',
+                            },
+                        ],
+                        internalType: 'struct TokenConfig[]',
+                        name: 'tokens',
+                        type: 'tuple[]',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'normalizedWeights',
+                        type: 'uint256[]',
+                    },
+                    {
+                        components: [
+                            {
+                                internalType: 'address',
+                                name: 'pauseManager',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'address',
+                                name: 'swapFeeManager',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'address',
+                                name: 'poolCreator',
+                                type: 'address',
+                            },
+                        ],
+                        internalType: 'struct PoolRoleAccounts',
+                        name: 'roleAccounts',
+                        type: 'tuple',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'swapFeePercentage',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'poolHooksContract',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'enableDonation',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'disableUnbalancedLiquidity',
+                        type: 'bool',
+                    },
+                    { internalType: 'bytes32', name: 'salt', type: 'bytes32' },
+                    {
+                        internalType: 'int256[]',
+                        name: '_initialWeights',
+                        type: 'int256[]',
+                    },
+                    {
+                        components: [
+                            {
+                                internalType: 'contract IERC20[]',
+                                name: 'assets',
+                                type: 'address[]',
+                            },
+                            {
+                                internalType: 'contract IUpdateRule',
+                                name: 'rule',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'address[][]',
+                                name: 'oracles',
+                                type: 'address[][]',
+                            },
+                            {
+                                internalType: 'uint16',
+                                name: 'updateInterval',
+                                type: 'uint16',
+                            },
+                            {
+                                internalType: 'uint64[]',
+                                name: 'lambda',
+                                type: 'uint64[]',
+                            },
+                            {
+                                internalType: 'uint64',
+                                name: 'epsilonMax',
+                                type: 'uint64',
+                            },
+                            {
+                                internalType: 'uint64',
+                                name: 'absoluteWeightGuardRail',
+                                type: 'uint64',
+                            },
+                            {
+                                internalType: 'uint64',
+                                name: 'maxTradeSizeRatio',
+                                type: 'uint64',
+                            },
+                            {
+                                internalType: 'int256[][]',
+                                name: 'ruleParameters',
+                                type: 'int256[][]',
+                            },
+                            {
+                                internalType: 'address',
+                                name: 'poolManager',
+                                type: 'address',
+                            },
+                        ],
+                        internalType:
+                            'struct IQuantAMMWeightedPool.PoolSettings',
+                        name: '_poolSettings',
+                        type: 'tuple',
+                    },
+                    {
+                        internalType: 'int256[]',
+                        name: '_initialMovingAverages',
+                        type: 'int256[]',
+                    },
+                    {
+                        internalType: 'int256[]',
+                        name: '_initialIntermediateValues',
+                        type: 'int256[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: '_oracleStalenessThreshold',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'poolRegistry',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'string[][]',
+                        name: 'poolDetails',
+                        type: 'string[][]',
+                    },
+                ],
+                internalType:
+                    'struct QuantAMMWeightedPoolFactory.CreationNewPoolParams',
+                name: 'params',
+                type: 'tuple',
+            },
+        ],
+        name: 'initialize',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        name: 'lambda',
+        outputs: [{ internalType: 'uint64', name: '', type: 'uint64' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'name',
+        outputs: [{ internalType: 'string', name: '', type: 'string' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
+        name: 'nonces',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'enum SwapKind',
+                        name: 'kind',
+                        type: 'uint8',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'amountGivenScaled18',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'balancesScaled18',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'indexIn',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'indexOut',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'router',
+                        type: 'address',
+                    },
+                    { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct PoolSwapParams',
+                name: 'request',
+                type: 'tuple',
+            },
+        ],
+        name: 'onSwap',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'owner', type: 'address' },
+            { internalType: 'address', name: 'spender', type: 'address' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+            { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+            { internalType: 'uint8', name: 'v', type: 'uint8' },
+            { internalType: 'bytes32', name: 'r', type: 'bytes32' },
+            { internalType: 'bytes32', name: 's', type: 'bytes32' },
+        ],
+        name: 'permit',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'poolRegistry',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'uint256', name: '', type: 'uint256' },
+            { internalType: 'uint256', name: '', type: 'uint256' },
+        ],
+        name: 'ruleParameters',
+        outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: '_updateWeightRunner',
+                type: 'address',
+            },
+        ],
+        name: 'setUpdateWeightRunnerAddress',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'int256[]', name: '_weights', type: 'int256[]' },
+            { internalType: 'address', name: '_address', type: 'address' },
+            {
+                internalType: 'uint40',
+                name: '_lastInteropTime',
+                type: 'uint40',
+            },
+        ],
+        name: 'setWeights',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'bytes4', name: 'interfaceId', type: 'bytes4' },
+        ],
+        name: 'supportsInterface',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'symbol',
+        outputs: [{ internalType: 'string', name: '', type: 'string' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'totalSupply',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'to', type: 'address' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'transfer',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'from', type: 'address' },
+            { internalType: 'address', name: 'to', type: 'address' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'transferFrom',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'updateInterval',
+        outputs: [{ internalType: 'uint64', name: '', type: 'uint64' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'updateWeightRunner',
+        outputs: [
+            {
+                internalType: 'contract UpdateWeightRunner',
+                name: '',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'version',
+        outputs: [{ internalType: 'string', name: '', type: 'string' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+] as const;

--- a/testData/src/buffer.ts
+++ b/testData/src/buffer.ts
@@ -7,6 +7,7 @@ import {
     erc4626Abi,
 } from 'viem';
 import { CHAINS, VAULT_V3 } from '@balancer/sdk';
+import { TransformBigintToString } from './types';
 
 export type BufferImmutable = {
     tokens: Address[];
@@ -14,14 +15,6 @@ export type BufferImmutable = {
 
 type BufferMutable = {
     rate: bigint;
-};
-
-type TransformBigintToString<T> = {
-    [K in keyof T]: T[K] extends bigint
-        ? string
-        : T[K] extends bigint[]
-          ? string[]
-          : T[K];
 };
 
 export class BufferPool {

--- a/testData/src/getPool.ts
+++ b/testData/src/getPool.ts
@@ -6,6 +6,7 @@ import { BufferPool } from './buffer';
 import { GyroECLPPool } from './gyroECLP';
 import { ReClammPool } from './reClamm';
 import { LiquidityBootstrappingPool } from './liquidityBootstrappingPool';
+import { QuantAmmPool } from './quantAmm';
 
 export async function getPool(
     rpcUrl: string,
@@ -23,6 +24,7 @@ export async function getPool(
         | GyroECLPPool
         | ReClammPool
         | LiquidityBootstrappingPool
+        | QuantAmmPool
     > = {
         WEIGHTED: new WeightedPool(rpcUrl, chainId),
         STABLE: new StablePool(rpcUrl, chainId),
@@ -33,6 +35,7 @@ export async function getPool(
             chainId,
         ),
         RECLAMM: new ReClammPool(rpcUrl, chainId),
+        QUANT_AMM_WEIGHTED: new QuantAmmPool(rpcUrl, chainId),
     };
     if (!poolData[poolType])
         throw new Error(`getPool: Unsupported pool type: ${poolType}`);

--- a/testData/src/gyroECLP.ts
+++ b/testData/src/gyroECLP.ts
@@ -9,6 +9,7 @@ import {
 import { CHAINS, VAULT_V3, vaultExtensionAbi_V3 } from '@balancer/sdk';
 import { vaultExplorerAbi } from './abi/vaultExplorer';
 import { gyroECLPAbi } from './abi/gyroECLP';
+import { TransformBigintToString } from './types';
 
 type GyroECLPMutable = {
     swapFee: bigint;
@@ -35,14 +36,6 @@ type GyroECLPImmutable = {
     w: bigint;
     z: bigint;
     dSq: bigint;
-};
-
-type TransformBigintToString<T> = {
-    [K in keyof T]: T[K] extends bigint
-        ? string
-        : T[K] extends bigint[]
-          ? string[]
-          : T[K];
 };
 
 export class GyroECLPPool {

--- a/testData/src/liquidityBootstrappingPool.ts
+++ b/testData/src/liquidityBootstrappingPool.ts
@@ -8,6 +8,7 @@ import {
 import { CHAINS } from '@balancer/sdk';
 import { VAULT_V3, vaultExtensionAbi_V3 } from '@balancer/sdk';
 import { liquidityBootstrappingAbi } from './abi/liquidityBootstrapping';
+import { TransformBigintToString } from './types';
 
 export type LBPoolImmutableData = {
     tokens: string[];
@@ -29,14 +30,6 @@ export type LBPoolDynamicData = {
     isPoolPaused: boolean;
     isPoolInRecoveryMode: boolean;
     isSwapEnabled: boolean;
-};
-
-type TransformBigintToString<T> = {
-    [K in keyof T]: T[K] extends bigint
-        ? string
-        : T[K] extends bigint[]
-          ? string[]
-          : T[K];
 };
 
 export class LiquidityBootstrappingPool {

--- a/testData/src/liquidityBootstrappingPool.ts
+++ b/testData/src/liquidityBootstrappingPool.ts
@@ -62,25 +62,21 @@ export class LiquidityBootstrappingPool {
         address: Address,
         blockNumber: bigint,
     ): Promise<TransformBigintToString<LBPoolImmutableData>> {
-        const call = {
-            address,
-            abi: liquidityBootstrappingAbi,
-            functionName: 'getLBPoolImmutableData',
-        } as const;
-
         const {
             tokens,
-            scalingFactors: decimalScalingFactors,
+            decimalScalingFactors,
             startWeights,
             endWeights,
             startTime,
             endTime,
             projectTokenIndex,
             isProjectTokenSwapInBlocked,
-        } = (await this.client.readContract({
-            ...call,
+        } = await this.client.readContract({
+            address,
+            abi: liquidityBootstrappingAbi,
+            functionName: 'getLBPoolImmutableData',
             blockNumber,
-        })) as LBPoolImmutableData;
+        });
 
         return {
             tokens: [...tokens],

--- a/testData/src/quantAmm.ts
+++ b/testData/src/quantAmm.ts
@@ -1,0 +1,112 @@
+import { PublicClient, Address, http, createPublicClient, Chain } from 'viem';
+import { quantAmmAbi } from './abi/quantAmm';
+import { VAULT_V3 } from '@balancer/sdk';
+import { CHAINS } from '@balancer/sdk';
+import { vaultExplorerAbi } from './abi/vaultExplorer';
+
+export interface QuantAmmMutableData {
+    balancesLiveScaled18: bigint[];
+    tokenRates: bigint[];
+    totalSupply: bigint;
+    firstFourWeightsAndMultipliers: bigint[];
+    secondFourWeightsAndMultipliers: bigint[];
+    lastUpdateTime: bigint;
+    lastInteropTime: bigint;
+    currentTimestamp: bigint;
+}
+
+export interface QuantAmmImmutableData {
+    tokens: string[];
+    maxTradeSizeRatio: bigint;
+    scalingFactors: bigint[];
+    swapFee: bigint;
+}
+
+type TransformBigintToString<T> = {
+    [K in keyof T]: T[K] extends bigint
+        ? string
+        : T[K] extends bigint[]
+          ? string[]
+          : T[K];
+};
+
+export class QuantAmmPool {
+    client: PublicClient;
+    vault: Address;
+
+    constructor(
+        public rpcUrl: string,
+        public chainId: number,
+    ) {
+        this.client = createPublicClient({
+            transport: http(this.rpcUrl),
+            chain: CHAINS[this.chainId] as Chain,
+        });
+        this.vault = VAULT_V3[this.chainId];
+    }
+
+    async fetchImmutableData(
+        address: Address,
+        blockNumber?: bigint,
+    ): Promise<TransformBigintToString<QuantAmmImmutableData>> {
+        const data = await this.client.readContract({
+            address,
+            abi: quantAmmAbi,
+            functionName: 'getQuantAMMWeightedPoolImmutableData',
+            blockNumber,
+        });
+
+        const [scalingFactors] = await this.client.readContract({
+            address: this.vault,
+            abi: vaultExplorerAbi,
+            functionName: 'getPoolTokenRates',
+            args: [address],
+            blockNumber,
+        });
+
+        const staticSwapFeePercentage = await this.client.readContract({
+            address,
+            abi: quantAmmAbi,
+            functionName: 'getStaticSwapFeePercentage',
+            blockNumber,
+        });
+
+        return {
+            tokens: data.tokens.map((token: string) => token.toLowerCase()),
+            maxTradeSizeRatio: data.maxTradeSizeRatio.toString(),
+            scalingFactors: scalingFactors.map((sf) => sf.toString()),
+            swapFee: staticSwapFeePercentage.toString(),
+        };
+    }
+
+    async fetchMutableData(
+        address: Address,
+        blockNumber?: bigint,
+    ): Promise<TransformBigintToString<QuantAmmMutableData>> {
+        const data = await this.client.readContract({
+            address,
+            abi: quantAmmAbi,
+            functionName: 'getQuantAMMWeightedPoolDynamicData',
+            blockNumber,
+        });
+
+        const block = await this.client.getBlock({
+            blockNumber,
+        });
+
+        return {
+            balancesLiveScaled18: data.balancesLiveScaled18.map((b) =>
+                b.toString(),
+            ),
+            tokenRates: data.tokenRates.map((b) => b.toString()),
+            totalSupply: data.totalSupply.toString(),
+            firstFourWeightsAndMultipliers:
+                data.firstFourWeightsAndMultipliers.map((b) => b.toString()),
+            secondFourWeightsAndMultipliers:
+                data.secondFourWeightsAndMultipliers.map((b) => b.toString()),
+            lastUpdateTime: data.lastUpdateTime.toString(),
+            lastInteropTime: data.lastInteropTime.toString(),
+            currentTimestamp: block.timestamp.toString(),
+        };
+    }
+}

--- a/testData/src/quantAmm.ts
+++ b/testData/src/quantAmm.ts
@@ -3,6 +3,7 @@ import { quantAmmAbi } from './abi/quantAmm';
 import { VAULT_V3 } from '@balancer/sdk';
 import { CHAINS } from '@balancer/sdk';
 import { vaultExplorerAbi } from './abi/vaultExplorer';
+import { TransformBigintToString } from './types';
 
 export interface QuantAmmMutableData {
     balancesLiveScaled18: bigint[];
@@ -21,14 +22,6 @@ export interface QuantAmmImmutableData {
     scalingFactors: bigint[];
     swapFee: bigint;
 }
-
-type TransformBigintToString<T> = {
-    [K in keyof T]: T[K] extends bigint
-        ? string
-        : T[K] extends bigint[]
-          ? string[]
-          : T[K];
-};
 
 export class QuantAmmPool {
     client: PublicClient;

--- a/testData/src/reClamm.ts
+++ b/testData/src/reClamm.ts
@@ -8,6 +8,7 @@ import {
 import { CHAINS, VAULT_V3, vaultExtensionAbi_V3 } from '@balancer/sdk';
 import { vaultExplorerAbi } from './abi/vaultExplorer';
 import { reclammAbi } from './abi/reClamm';
+import { TransformBigintToString } from './types';
 
 type ReClammMutable = {
     swapFee: bigint;
@@ -31,14 +32,6 @@ type ReClammMutable = {
 type ReClammImmutable = {
     tokens: bigint[];
     scalingFactors: bigint[];
-};
-
-type TransformBigintToString<T> = {
-    [K in keyof T]: T[K] extends bigint
-        ? string
-        : T[K] extends bigint[]
-          ? string[]
-          : T[K];
 };
 
 export class ReClammPool {

--- a/testData/src/stablePool.ts
+++ b/testData/src/stablePool.ts
@@ -8,6 +8,7 @@ import {
 } from 'viem';
 import { CHAINS, VAULT_V3, vaultExtensionAbi_V3 } from '@balancer/sdk';
 import { vaultExplorerAbi } from './abi/vaultExplorer';
+import { TransformBigintToString } from './types';
 
 type StableMutable = {
     amp: bigint;
@@ -21,14 +22,6 @@ type StableMutable = {
 type StableImmutable = {
     tokens: bigint[];
     scalingFactors: bigint[];
-};
-
-type TransformBigintToString<T> = {
-    [K in keyof T]: T[K] extends bigint
-        ? string
-        : T[K] extends bigint[]
-          ? string[]
-          : T[K];
 };
 
 export class StablePool {

--- a/testData/src/types.ts
+++ b/testData/src/types.ts
@@ -33,3 +33,11 @@ export type TestOutput = {
     adds: AddLiquidityResult[] | undefined;
     removes: RemoveLiquidityResult[] | undefined;
 };
+
+export type TransformBigintToString<T> = {
+    [K in keyof T]: T[K] extends bigint
+        ? string
+        : T[K] extends bigint[]
+          ? string[]
+          : T[K];
+};

--- a/testData/src/weightedPool.ts
+++ b/testData/src/weightedPool.ts
@@ -8,6 +8,7 @@ import {
 } from 'viem';
 import { CHAINS, VAULT_V3, vaultExtensionAbi_V3 } from '@balancer/sdk';
 import { vaultExplorerAbi } from './abi/vaultExplorer';
+import { TransformBigintToString } from './types';
 
 export type WeightedImmutable = {
     tokens: bigint[];
@@ -21,14 +22,6 @@ type WeightedMutable = {
     balancesLiveScaled18: bigint[];
     tokenRates: bigint[];
     aggregateSwapFee: bigint;
-};
-
-type TransformBigintToString<T> = {
-    [K in keyof T]: T[K] extends bigint
-        ? string
-        : T[K] extends bigint[]
-          ? string[]
-          : T[K];
 };
 
 export class WeightedPool {

--- a/testData/testData/11155111-8085514-LBP-BAL-DAI.json
+++ b/testData/testData/11155111-8085514-LBP-BAL-DAI.json
@@ -38,18 +38,36 @@
             "0xb19382073c7A0aDdbb56Ac6AF1808Fa49e377B75",
             "0xB77EB1A70A96fDAAeB31DB1b42F2b8b5846b2613"
         ],
-        "scalingFactors": ["1", "1"],
-        "startWeights": ["500000000000000000", "500000000000000000"],
-        "endWeights": ["100000000000000000", "900000000000000000"],
+        "scalingFactors": [
+            "1",
+            "1"
+        ],
+        "startWeights": [
+            "500000000000000000",
+            "500000000000000000"
+        ],
+        "endWeights": [
+            "100000000000000000",
+            "900000000000000000"
+        ],
         "startTime": "1744204169",
         "endTime": "1744546169",
         "projectTokenIndex": 0,
         "isProjectTokenSwapInBlocked": false,
-        "balancesLiveScaled18": ["1000000000000000000", "1000000000000000000"],
-        "weights": ["480300584795321638", "519699415204678362"],
+        "balancesLiveScaled18": [
+            "1000000000000000000",
+            "1000000000000000000"
+        ],
+        "weights": [
+            "480300584795321638",
+            "519699415204678362"
+        ],
         "swapFee": "3000000000000000",
         "totalSupply": "999999999999979998",
-        "tokenRates": ["1000000000000000000", "1000000000000000000"],
+        "tokenRates": [
+            "1000000000000000000",
+            "1000000000000000000"
+        ],
         "isPoolInitialized": true,
         "isPoolPaused": false,
         "isPoolInRecoveryMode": false,

--- a/testData/testData/11155111-8275355-QuantAMM.json
+++ b/testData/testData/11155111-8275355-QuantAMM.json
@@ -1,0 +1,148 @@
+{
+    "swaps": [
+        {
+            "swapKind": 0,
+            "amountRaw": "10000000",
+            "tokenIn": "0x29f2d40b0605204364af54ec677bd022da425d03",
+            "tokenOut": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+            "outputRaw": "9996948"
+        },
+        {
+            "swapKind": 1,
+            "amountRaw": "100000",
+            "tokenIn": "0x29f2d40b0605204364af54ec677bd022da425d03",
+            "tokenOut": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+            "outputRaw": "99108"
+        },
+        {
+            "swapKind": 0,
+            "amountRaw": "1000000",
+            "tokenIn": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+            "tokenOut": "0x29f2d40b0605204364af54ec677bd022da425d03",
+            "outputRaw": "970368"
+        },
+        {
+            "swapKind": 1,
+            "amountRaw": "2000000",
+            "tokenIn": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+            "tokenOut": "0x29f2d40b0605204364af54ec677bd022da425d03",
+            "outputRaw": "2063093"
+        }
+    ],
+    "adds": [
+        {
+            "kind": "Unbalanced",
+            "inputAmountsRaw": [
+                "10000000",
+                "10000000"
+            ],
+            "bptOutRaw": "999973433631575523"
+        },
+        {
+            "kind": "SingleToken",
+            "inputAmountsRaw": [
+                "1",
+                "0"
+            ],
+            "bptOutRaw": "10000000"
+        },
+        {
+            "kind": "SingleToken",
+            "inputAmountsRaw": [
+                "0",
+                "1"
+            ],
+            "bptOutRaw": "10000000"
+        }
+    ],
+    "removes": [
+        {
+            "kind": "Proportional",
+            "amountsOutRaw": [
+                "990515",
+                "1009623"
+            ],
+            "bptInRaw": "100000000000000000"
+        },
+        {
+            "kind": "SingleTokenExactIn",
+            "amountsOutRaw": [
+                "1970203",
+                "0"
+            ],
+            "bptInRaw": "100000000000000000"
+        },
+        {
+            "kind": "SingleTokenExactIn",
+            "amountsOutRaw": [
+                "0",
+                "2008209"
+            ],
+            "bptInRaw": "100000000000000000"
+        },
+        {
+            "kind": "SingleTokenExactOut",
+            "amountsOutRaw": [
+                "10000000",
+                "0"
+            ],
+            "bptInRaw": "508547636144733036"
+        },
+        {
+            "kind": "SingleTokenExactOut",
+            "amountsOutRaw": [
+                "0",
+                "10000000"
+            ],
+            "bptInRaw": "498900641790957372"
+        }
+    ],
+    "pool": {
+        "chainId": "11155111",
+        "blockNumber": "8275355",
+        "poolType": "QUANT_AMM_WEIGHTED",
+        "poolAddress": "0xa3a6398f3b29b84a6657a1f4bce5c90f38462bf7",
+        "tokens": [
+            "0x29f2d40b0605204364af54ec677bd022da425d03",
+            "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8"
+        ],
+        "maxTradeSizeRatio": "10000000000000000",
+        "scalingFactors": [
+            "10000000000",
+            "1000000000000"
+        ],
+        "swapFee": "10000000000000000",
+        "balancesLiveScaled18": [
+            "10525824160000000000",
+            "1072887109000000000000"
+        ],
+        "tokenRates": [
+            "1000000000000000000",
+            "1000000000000000000"
+        ],
+        "totalSupply": "106266075432411920362",
+        "firstFourWeightsAndMultipliers": [
+            "500000000000000000",
+            "500000000000000000",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0"
+        ],
+        "secondFourWeightsAndMultipliers": [
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0"
+        ],
+        "lastUpdateTime": "1742206416",
+        "lastInteropTime": "1742206416",
+        "currentTimestamp": "1746623760"
+    }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -9,7 +9,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "version": "0.0.28",
+    "version": "0.0.29",
     "main": "dist/index.js",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",

--- a/typescript/src/gyro/gyroECLPMath.ts
+++ b/typescript/src/gyro/gyroECLPMath.ts
@@ -412,7 +412,7 @@ export class GyroECLPMath {
             // In the false case here, the extra precision error does not magnify, and so the error inside the sqrt is
             // O(1e-18)
             // somedayTODO: The true case will almost surely never happen (can it be removed)
-            err = err > 0 ? GyroPoolMath.sqrt(err, 5n) : BigInt(1e9);
+            err = err > 0 ? GyroPoolMath.sqrt(err, 5n) : BigInt('1000000000');
         }
         // Calculate the error in the numerator, scale the error by 20 to be sure all possible terms accounted for
         err =
@@ -448,7 +448,7 @@ export class GyroECLPMath {
         err =
             err +
             (SignedFixedPoint.mulUpXpToNpU(invariant, mulDenominator) *
-                ((params.lambda * params.lambda) / BigInt(1e36)) *
+                ((params.lambda * params.lambda) / BigInt('1000000000000000000000000000000000000')) *
                 40n) /
                 this._ONE_XP +
             1n;

--- a/typescript/src/quantAmm/index.ts
+++ b/typescript/src/quantAmm/index.ts
@@ -1,0 +1,3 @@
+export * from './quantAmmData';
+export * from './quantAmmMath';
+export * from './quantAmmPool';

--- a/typescript/src/quantAmm/quantAmmData.ts
+++ b/typescript/src/quantAmm/quantAmmData.ts
@@ -1,0 +1,20 @@
+import { BasePoolState } from '@/vault/types';
+
+type PoolType = 'QUANT_AMM_WEIGHTED';
+
+export type QuantAmmMutable = {
+    firstFourWeightsAndMultipliers: bigint[];
+    secondFourWeightsAndMultipliers: bigint[];
+    lastUpdateTime: bigint;
+    lastInteropTime: bigint;
+    currentTimestamp: bigint;
+};
+
+export type QuantAmmImmutable = {
+    maxTradeSizeRatio: bigint;
+};
+
+export type QuantAmmState = BasePoolState & {
+    poolType: PoolType;
+} & QuantAmmMutable &
+    QuantAmmImmutable;

--- a/typescript/src/quantAmm/quantAmmMath.ts
+++ b/typescript/src/quantAmm/quantAmmMath.ts
@@ -39,12 +39,12 @@ export const getFirstFourWeightsAndMultipliers = (
     tokens: string[],
     firstFourWeightsAndMultipliers: bigint[],
 ): { weights: bigint[]; multipliers: bigint[] } => {
-    const weights = new Array(tokens.length).fill(0n);
-    const multipliers = new Array(tokens.length).fill(0n);
-
     const lessThan4TokensOffset = tokens.length > 4 ? 4 : tokens.length;
 
-    for (let i = 0; i < tokens.length; i++) {
+    const weights = new Array(lessThan4TokensOffset).fill(0n);
+    const multipliers = new Array(lessThan4TokensOffset).fill(0n);
+
+    for (let i = 0; i < lessThan4TokensOffset; i++) {
         weights[i] = firstFourWeightsAndMultipliers[i];
         multipliers[i] =
             firstFourWeightsAndMultipliers[i + lessThan4TokensOffset];
@@ -57,12 +57,16 @@ export const getSecondFourWeightsAndMultipliers = (
     tokens: string[],
     secondFourWeightsAndMultipliers: bigint[],
 ): { weights: bigint[]; multipliers: bigint[] } => {
-    const weights = new Array(tokens.length).fill(0n);
-    const multipliers = new Array(tokens.length).fill(0n);
+    if (tokens.length <= 4) {
+        return { weights: [], multipliers: [] };
+    }
 
     const moreThan4TokensOffset = tokens.length - 4;
 
-    for (let i = 0; i < tokens.length; i++) {
+    const weights = new Array(moreThan4TokensOffset).fill(0n);
+    const multipliers = new Array(moreThan4TokensOffset).fill(0n);
+
+    for (let i = 0; i < moreThan4TokensOffset; i++) {
         weights[i] = secondFourWeightsAndMultipliers[i];
         multipliers[i] =
             secondFourWeightsAndMultipliers[i + moreThan4TokensOffset];

--- a/typescript/src/quantAmm/quantAmmMath.ts
+++ b/typescript/src/quantAmm/quantAmmMath.ts
@@ -1,0 +1,72 @@
+import { MathSol } from '../utils/math';
+
+/**
+ * @notice Calculate the current block weight based on time interpolation
+ * @param weight The base weight
+ * @param multiplier The weight multiplier
+ * @param timeSinceLastUpdate The time since the last weight update
+ * @return The interpolated weight
+ */
+export const calculateBlockNormalisedWeight = (
+    weight: bigint,
+    multiplier: bigint,
+    timeSinceLastUpdate: bigint,
+): bigint => {
+    // multiplier is always below 1, we multiply by 1e18 for rounding
+    const multiplierScaled18 = multiplier * BigInt(1e18);
+
+    if (multiplier > 0n) {
+        return (
+            weight +
+            MathSol.mulDownFixed(multiplierScaled18, timeSinceLastUpdate)
+        );
+    } else {
+        return (
+            weight -
+            MathSol.mulDownFixed(-multiplierScaled18, timeSinceLastUpdate)
+        );
+    }
+};
+
+/**
+ * Both functions below are simplified versions of the SC implementation.
+ * They extract weights and multipliers from mutable data fecthed on-chain, which
+ * are packed and stored in 256-bit words for storage efficiency, but here can
+ * be unpacked into separate weights and multipliers arrays.
+ */
+
+export const getFirstFourWeightsAndMultipliers = (
+    tokens: string[],
+    firstFourWeightsAndMultipliers: bigint[],
+): { weights: bigint[]; multipliers: bigint[] } => {
+    const weights = new Array(tokens.length).fill(0n);
+    const multipliers = new Array(tokens.length).fill(0n);
+
+    const lessThan4TokensOffset = tokens.length > 4 ? 4 : tokens.length;
+
+    for (let i = 0; i < tokens.length; i++) {
+        weights[i] = firstFourWeightsAndMultipliers[i];
+        multipliers[i] =
+            firstFourWeightsAndMultipliers[i + lessThan4TokensOffset];
+    }
+
+    return { weights, multipliers };
+};
+
+export const getSecondFourWeightsAndMultipliers = (
+    tokens: string[],
+    secondFourWeightsAndMultipliers: bigint[],
+): { weights: bigint[]; multipliers: bigint[] } => {
+    const weights = new Array(tokens.length).fill(0n);
+    const multipliers = new Array(tokens.length).fill(0n);
+
+    const moreThan4TokensOffset = tokens.length - 4;
+
+    for (let i = 0; i < tokens.length; i++) {
+        weights[i] = secondFourWeightsAndMultipliers[i];
+        multipliers[i] =
+            secondFourWeightsAndMultipliers[i + moreThan4TokensOffset];
+    }
+
+    return { weights, multipliers };
+};

--- a/typescript/src/quantAmm/quantAmmMath.ts
+++ b/typescript/src/quantAmm/quantAmmMath.ts
@@ -13,7 +13,7 @@ export const calculateBlockNormalisedWeight = (
     timeSinceLastUpdate: bigint,
 ): bigint => {
     // multiplier is always below 1, we multiply by 1e18 for rounding
-    const multiplierScaled18 = multiplier * BigInt(1e18);
+    const multiplierScaled18 = multiplier * BigInt('1000000000000000000');
 
     if (multiplier > 0n) {
         return (

--- a/typescript/src/quantAmm/quantAmmPool.ts
+++ b/typescript/src/quantAmm/quantAmmPool.ts
@@ -6,8 +6,7 @@ import {
     _computeOutGivenExactIn,
     _MAX_INVARIANT_RATIO,
     _MIN_INVARIANT_RATIO,
-    Weighted,
-} from '@/weighted';
+} from '../weighted';
 import {
     SwapKind,
     type SwapParams,
@@ -23,7 +22,7 @@ import {
     getSecondFourWeightsAndMultipliers,
 } from './quantAmmMath';
 import { QuantAmmState } from './quantAmmData';
-import { toRawUndoRateRoundDown } from '@/vault/utils';
+import { toRawUndoRateRoundDown } from '../vault/utils';
 
 export class QuantAmm implements PoolBase {
     private weights: bigint[];

--- a/typescript/src/quantAmm/quantAmmPool.ts
+++ b/typescript/src/quantAmm/quantAmmPool.ts
@@ -1,0 +1,308 @@
+import {
+    _computeBalanceOutGivenInvariant,
+    _computeInGivenExactOut,
+    _computeInvariantDown,
+    _computeInvariantUp,
+    _computeOutGivenExactIn,
+    _MAX_INVARIANT_RATIO,
+    _MIN_INVARIANT_RATIO,
+    Weighted,
+} from '@/weighted';
+import {
+    SwapKind,
+    type SwapParams,
+    type MaxSwapParams,
+    Rounding,
+    PoolBase,
+    MaxSingleTokenRemoveParams,
+} from '../vault/types';
+import { MathSol, MAX_UINT256 } from '../utils/math';
+import {
+    calculateBlockNormalisedWeight,
+    getFirstFourWeightsAndMultipliers,
+    getSecondFourWeightsAndMultipliers,
+} from './quantAmmMath';
+import { QuantAmmState } from './quantAmmData';
+import { toRawUndoRateRoundDown } from '@/vault/utils';
+
+export class QuantAmm implements PoolBase {
+    private weights: bigint[];
+    private multipliers: bigint[];
+
+    constructor(private quantAmmState: QuantAmmState) {
+        const first = getFirstFourWeightsAndMultipliers(
+            quantAmmState.tokens,
+            quantAmmState.firstFourWeightsAndMultipliers,
+        );
+        const second = getSecondFourWeightsAndMultipliers(
+            quantAmmState.tokens,
+            quantAmmState.secondFourWeightsAndMultipliers,
+        );
+
+        this.weights = [...first.weights, ...second.weights];
+        this.multipliers = [...first.multipliers, ...second.multipliers];
+    }
+
+    getMaximumInvariantRatio(): bigint {
+        return _MAX_INVARIANT_RATIO;
+    }
+
+    getMinimumInvariantRatio(): bigint {
+        return _MIN_INVARIANT_RATIO;
+    }
+
+    getMaxSwapAmount(maxSwapParams: MaxSwapParams): bigint {
+        const {
+            balancesLiveScaled18,
+            indexIn,
+            indexOut,
+            tokenRates,
+            scalingFactors,
+            swapKind,
+        } = maxSwapParams;
+
+        if (swapKind === SwapKind.GivenIn) {
+            const max18 = MathSol.mulDownFixed(
+                balancesLiveScaled18[indexIn],
+                this.quantAmmState.maxTradeSizeRatio,
+            );
+            // Scale to token in (and remove rate)
+            return toRawUndoRateRoundDown(
+                max18,
+                scalingFactors[indexIn],
+                tokenRates[indexIn],
+            );
+        }
+
+        const max18 = MathSol.mulDownFixed(
+            balancesLiveScaled18[indexOut],
+            this.quantAmmState.maxTradeSizeRatio,
+        );
+        // Scale to token out
+        return toRawUndoRateRoundDown(
+            max18,
+            scalingFactors[indexOut],
+            tokenRates[indexOut],
+        );
+    }
+
+    getMaxSingleTokenAddAmount(): bigint {
+        return MAX_UINT256;
+    }
+
+    getMaxSingleTokenRemoveAmount(
+        maxRemoveParams: MaxSingleTokenRemoveParams,
+    ): bigint {
+        const {
+            isExactIn,
+            totalSupply,
+            tokenOutBalance,
+            tokenOutScalingFactor,
+            tokenOutRate,
+        } = maxRemoveParams;
+        return this.getMaxSwapAmount({
+            swapKind: isExactIn ? SwapKind.GivenIn : SwapKind.GivenOut,
+            balancesLiveScaled18: [totalSupply, tokenOutBalance],
+            tokenRates: [1000000000000000000n, tokenOutRate],
+            scalingFactors: [1000000000000000000n, tokenOutScalingFactor],
+            indexIn: 0,
+            indexOut: 1,
+        });
+    }
+
+    onSwap(swapParams: SwapParams): bigint {
+        const {
+            swapKind,
+            balancesLiveScaled18,
+            indexIn,
+            indexOut,
+            amountGivenScaled18,
+        } = swapParams;
+
+        let multiplierTime = this.quantAmmState.currentTimestamp;
+
+        if (
+            this.quantAmmState.currentTimestamp >=
+            this.quantAmmState.lastInteropTime
+        ) {
+            multiplierTime = this.quantAmmState.lastInteropTime;
+        }
+
+        const timeSinceLastUpdate =
+            multiplierTime - this.quantAmmState.lastUpdateTime;
+
+        // Get current weights based on time interpolation
+        const { tokenInWeight, tokenOutWeight } = this._getNormalizedWeightPair(
+            indexIn,
+            indexOut,
+            timeSinceLastUpdate,
+            this.weights,
+            this.multipliers,
+        );
+
+        if (swapKind === SwapKind.GivenIn) {
+            // Check max trade size ratio
+            if (
+                amountGivenScaled18 >
+                MathSol.mulDownFixed(
+                    balancesLiveScaled18[indexIn],
+                    this.quantAmmState.maxTradeSizeRatio,
+                )
+            ) {
+                throw new Error('MaxTradeSizeRatio exceeded');
+            }
+
+            const amountOutScaled18 = _computeOutGivenExactIn(
+                balancesLiveScaled18[indexIn],
+                tokenInWeight,
+                balancesLiveScaled18[indexOut],
+                tokenOutWeight,
+                amountGivenScaled18,
+            );
+
+            // Check max trade size ratio for output
+            if (
+                amountOutScaled18 >
+                MathSol.mulDownFixed(
+                    balancesLiveScaled18[indexOut],
+                    this.quantAmmState.maxTradeSizeRatio,
+                )
+            ) {
+                throw new Error('MaxTradeSizeRatio exceeded');
+            }
+
+            return amountOutScaled18;
+        } else {
+            // Swap Given Out
+
+            // Check max trade size ratio for output
+            if (
+                amountGivenScaled18 >
+                MathSol.mulDownFixed(
+                    balancesLiveScaled18[indexOut],
+                    this.quantAmmState.maxTradeSizeRatio,
+                )
+            ) {
+                throw new Error('MaxTradeSizeRatio exceeded');
+            }
+
+            const amountInScaled18 = _computeInGivenExactOut(
+                balancesLiveScaled18[indexIn],
+                tokenInWeight,
+                balancesLiveScaled18[indexOut],
+                tokenOutWeight,
+                amountGivenScaled18,
+            );
+
+            // Check max trade size ratio for input
+            if (
+                amountInScaled18 >
+                MathSol.mulDownFixed(
+                    balancesLiveScaled18[indexIn],
+                    this.quantAmmState.maxTradeSizeRatio,
+                )
+            ) {
+                throw new Error('MaxTradeSizeRatio exceeded');
+            }
+
+            return amountInScaled18;
+        }
+    }
+
+    computeInvariant(
+        balancesLiveScaled18: bigint[],
+        rounding: Rounding,
+    ): bigint {
+        let multiplierTime = this.quantAmmState.currentTimestamp;
+
+        if (
+            this.quantAmmState.currentTimestamp >=
+            this.quantAmmState.lastInteropTime
+        ) {
+            multiplierTime = this.quantAmmState.lastInteropTime;
+        }
+
+        const timeSinceLastUpdate =
+            multiplierTime - this.quantAmmState.lastUpdateTime;
+
+        const normalizedWeights = this._getNormalizedWeights(
+            timeSinceLastUpdate,
+            this.weights,
+            this.multipliers,
+        );
+        if (rounding === Rounding.ROUND_UP) {
+            return _computeInvariantUp(normalizedWeights, balancesLiveScaled18);
+        }
+        return _computeInvariantDown(normalizedWeights, balancesLiveScaled18);
+    }
+
+    computeBalance(
+        balancesLiveScaled18: bigint[],
+        tokenInIndex: number,
+        invariantRatio: bigint,
+    ): bigint {
+        let multiplierTime = this.quantAmmState.currentTimestamp;
+
+        if (
+            this.quantAmmState.currentTimestamp >=
+            this.quantAmmState.lastInteropTime
+        ) {
+            multiplierTime = this.quantAmmState.lastInteropTime;
+        }
+
+        const timeSinceLastUpdate =
+            multiplierTime - this.quantAmmState.lastUpdateTime;
+
+        const normalizedWeights = this._getNormalizedWeights(
+            timeSinceLastUpdate,
+            this.weights,
+            this.multipliers,
+        );
+        return _computeBalanceOutGivenInvariant(
+            balancesLiveScaled18[tokenInIndex],
+            normalizedWeights[tokenInIndex],
+            invariantRatio,
+        );
+    }
+
+    private _getNormalizedWeightPair(
+        indexIn: number,
+        indexOut: number,
+        timeSinceLastUpdate: bigint,
+        weights: bigint[],
+        multipliers: bigint[],
+    ): { tokenInWeight: bigint; tokenOutWeight: bigint } {
+        // Calculate weights based on time interpolation
+        const tokenInWeight = calculateBlockNormalisedWeight(
+            weights[indexIn],
+            multipliers[indexIn],
+            timeSinceLastUpdate,
+        );
+
+        const tokenOutWeight = calculateBlockNormalisedWeight(
+            weights[indexOut],
+            multipliers[indexOut],
+            timeSinceLastUpdate,
+        );
+
+        return { tokenInWeight, tokenOutWeight };
+    }
+
+    private _getNormalizedWeights(
+        timeSinceLastUpdate: bigint,
+        weights: bigint[],
+        multipliers: bigint[],
+    ): bigint[] {
+        const normalizedWeights = new Array(weights.length).fill(0n);
+
+        for (let i = 0; i < weights.length; i++) {
+            normalizedWeights[i] = calculateBlockNormalisedWeight(
+                weights[i],
+                multipliers[i],
+                timeSinceLastUpdate,
+            );
+        }
+
+        return normalizedWeights;
+    }
+}

--- a/typescript/src/stable/stableMath.ts
+++ b/typescript/src/stable/stableMath.ts
@@ -1,9 +1,9 @@
 import { MathSol } from '../utils/math';
 
 // Invariant growth limit: non-proportional add cannot cause the invariant to increase by more than this ratio.
-export const _MIN_INVARIANT_RATIO = BigInt(60e16); // 60%
+export const _MIN_INVARIANT_RATIO = BigInt('600000000000000000'); // 60%
 // Invariant shrink limit: non-proportional remove cannot cause the invariant to decrease by less than this ratio.
-export const _MAX_INVARIANT_RATIO = BigInt(500e16); // 500%
+export const _MAX_INVARIANT_RATIO = BigInt('5000000000000000000'); // 500%
 
 // For security reasons, to help ensure that for all possible "round trip" paths
 // the caller always receives the same or fewer tokens than supplied,

--- a/typescript/src/vault/types.ts
+++ b/typescript/src/vault/types.ts
@@ -2,6 +2,7 @@ import { GyroECLPState } from '@/gyro';
 import { StableState } from '@/stable';
 import { WeightedState } from '@/weighted';
 import { ReClammState } from '@/reClamm';
+import { QuantAmmState } from '@/quantAmm';
 
 /**
  * State of a pool. Note - rates, fees, totalSupply use scaled 18.
@@ -25,7 +26,8 @@ export type PoolState =
     | WeightedState
     | StableState
     | GyroECLPState
-    | ReClammState;
+    | ReClammState
+    | QuantAmmState;
 
 export enum SwapKind {
     GivenIn = 0,

--- a/typescript/src/vault/vault.ts
+++ b/typescript/src/vault/vault.ts
@@ -10,6 +10,7 @@ import { Weighted } from '../weighted';
 import { Stable } from '../stable';
 import { GyroECLP } from '../gyro';
 import { ReClamm } from '../reClamm';
+import { QuantAmm } from '../quantAmm';
 import { LiquidityBootstrapping } from '../liquidityBootstrapping';
 
 import { BufferState, erc4626BufferWrapOrUnwrap } from '../buffer';
@@ -63,6 +64,7 @@ export class Vault {
             GYROE: GyroECLP,
             RECLAMM: ReClamm,
             LIQUIDITY_BOOTSTRAPPING: LiquidityBootstrapping,
+            QUANT_AMM_WEIGHTED: QuantAmm,
             // custom add liquidity types take precedence over base types
             ...customPoolClasses,
         };

--- a/typescript/src/weighted/weightedMath.ts
+++ b/typescript/src/weighted/weightedMath.ts
@@ -2,19 +2,19 @@ import { MathSol, WAD } from '../utils/math';
 
 // A minimum normalized weight imposes a maximum weight ratio. We need this due to limitations in the
 // implementation of the power function, as these ratios are often exponents.
-export const _MIN_WEIGHT = BigInt(0.01e18);
+export const _MIN_WEIGHT = BigInt('10000000000000000'); // 0.01e18
 
 // Pool limits that arise from limitations in the fixed point power function (and the imposed 1:100 maximum weight
 // ratio).
 
 // Swap limits: amounts swapped may not be larger than this percentage of the total balance.
-export const _MAX_IN_RATIO = BigInt(0.3e18);
-export const _MAX_OUT_RATIO = BigInt(0.3e18);
+export const _MAX_IN_RATIO = BigInt('300000000000000000'); // 0.3e18
+export const _MAX_OUT_RATIO = BigInt('300000000000000000'); // 0.3e18
 
 // Invariant growth limit: non-proportional joins cannot cause the invariant to increase by more than this ratio.
-export const _MAX_INVARIANT_RATIO = BigInt(3e18);
+export const _MAX_INVARIANT_RATIO = BigInt('3000000000000000000'); // 3e18
 // Invariant shrink limit: non-proportional exits cannot cause the invariant to decrease by less than this ratio.
-export const _MIN_INVARIANT_RATIO = BigInt(0.7e18);
+export const _MIN_INVARIANT_RATIO = BigInt('700000000000000000'); // 0.7e18
 
 /**
  * @notice Compute the invariant, rounding down.

--- a/typescript/test/swaps.test.ts
+++ b/typescript/test/swaps.test.ts
@@ -50,6 +50,6 @@ function areBigIntsWithinPercent(
     const difference = value1 > value2 ? value1 - value2 : value2 - value1;
     console.log('Buffer Difference: ', difference);
     const percentFactor = BigInt(Math.floor(percent * 1e8));
-    const tolerance = (value2 * percentFactor) / BigInt(1e10);
+    const tolerance = (value2 * percentFactor) / BigInt('10000000000');
     return difference <= tolerance;
 }

--- a/typescript/test/utils/readTestData.ts
+++ b/typescript/test/utils/readTestData.ts
@@ -6,6 +6,7 @@ import type { WeightedState } from '@/weighted/data';
 import type { LiquidityBootstrappingState } from '@/liquidityBootstrapping';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { QuantAmmState } from '@/quantAmm/quantAmmData';
 
 type PoolBase = {
     chainId: number;
@@ -25,13 +26,16 @@ type ReClammPool = PoolBase & ReClammState;
 
 type LiquidityBootstrappingPool = PoolBase & LiquidityBootstrappingState;
 
+type QuantAmmPool = PoolBase & QuantAmmState;
+
 type SupportedPools =
     | WeightedPool
     | StablePool
     | BufferPool
     | GyroEPool
     | ReClammPool
-    | LiquidityBootstrappingPool;
+    | LiquidityBootstrappingPool
+    | QuantAmmPool;
 
 type PoolsMap = Map<string, SupportedPools>;
 
@@ -273,6 +277,31 @@ function mapPool(
             // of this being within maths/SOR, we set it to false
             supportsUnbalancedLiquidity: false,
             currentTimestamp: BigInt(pool.currentTimestamp ?? Date.now()),
+        };
+    }
+    if (pool.poolType === 'QUANT_AMM_WEIGHTED') {
+        return {
+            ...pool,
+            scalingFactors: pool.scalingFactors.map((sf) => BigInt(sf)),
+            swapFee: BigInt(pool.swapFee),
+            balancesLiveScaled18: pool.balancesLiveScaled18.map((b) =>
+                BigInt(b),
+            ),
+            tokenRates: pool.tokenRates.map((r) => BigInt(r)),
+            totalSupply: BigInt(pool.totalSupply),
+            aggregateSwapFee: BigInt(pool.aggregateSwapFee ?? '0'),
+            supportsUnbalancedLiquidity:
+                pool.supportsUnbalancedLiquidity === undefined
+                    ? true
+                    : pool.supportsUnbalancedLiquidity,
+            maxTradeSizeRatio: BigInt(pool.maxTradeSizeRatio),
+            firstFourWeightsAndMultipliers:
+                pool.firstFourWeightsAndMultipliers.map((w) => BigInt(w)),
+            secondFourWeightsAndMultipliers:
+                pool.secondFourWeightsAndMultipliers.map((w) => BigInt(w)),
+            currentTimestamp: BigInt(pool.currentTimestamp),
+            lastInteropTime: BigInt(pool.lastInteropTime),
+            lastUpdateTime: BigInt(pool.lastUpdateTime),
         };
     }
     console.log(pool);


### PR DESCRIPTION
Closes #104 

This PR adds QuantAmm math for swaps, adds and removes to balancer-maths typescript implementation.

Also as side tasks:
- reduce code repetition for some types
- fix LBP testData generation that wasn't working on my end